### PR TITLE
Ensure `uuid` is always unique

### DIFF
--- a/dev-null-plugin-http/src/http_static.rs
+++ b/dev-null-plugin-http/src/http_static.rs
@@ -1,21 +1,13 @@
-use std::{
-    collections::BTreeMap,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::{collections::BTreeMap, sync::atomic::Ordering};
 use tracing::{debug, instrument};
 
 use crate::config::internal::*;
 use async_trait::async_trait;
 use bytes::Bytes;
-use lazy_static::lazy_static;
 use serde_json::Value;
 use tokio::time::sleep;
 
 use http::{HeaderMap, Method, Response, Uri};
-
-lazy_static! {
-    static ref ID_COUNTER: AtomicU64 = AtomicU64::from(0);
-}
 
 impl StaticResponse {
     #[instrument(skip_all, fields(payload.id = payload_id))]
@@ -33,8 +25,6 @@ impl StaticResponse {
         sleep(self.delay).await;
 
         let values = BTreeMap::from([
-            ("uuid", Value::from(uuid::Uuid::new_v4().to_string())),
-            ("id", Value::from(ID_COUNTER.fetch_add(1, Ordering::SeqCst))),
             ("dev_null_payload_id", Value::from(payload_id)),
             ("request_body", body_string),
         ]);

--- a/dev-null-plugin-http/src/lib.rs
+++ b/dev-null-plugin-http/src/lib.rs
@@ -4,15 +4,46 @@ mod config;
 mod http_static;
 
 use dev_null_config::prelude::StaticHttpConfig;
-use handlebars::Handlebars;
+use handlebars::{Context, Handlebars, Helper, HelperResult, Output, RenderContext};
 use lazy_static::lazy_static;
-use std::sync::RwLock;
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    sync::RwLock,
+};
 use tracing::debug;
+
+lazy_static! {
+    static ref ID_COUNTER: AtomicU64 = AtomicU64::from(0);
+}
+
+fn uuid_generator(
+    _h: &Helper,
+    _: &Handlebars,
+    _: &Context,
+    _rc: &mut RenderContext,
+    out: &mut dyn Output,
+) -> HelperResult {
+    out.write(&uuid::Uuid::new_v4().to_string())?;
+    Ok(())
+}
+
+fn id_generator(
+    _h: &Helper,
+    _: &Handlebars,
+    _: &Context,
+    _rc: &mut RenderContext,
+    out: &mut dyn Output,
+) -> HelperResult {
+    out.write(&ID_COUNTER.fetch_add(1, Ordering::SeqCst).to_string())?;
+    Ok(())
+}
 
 lazy_static! {
     pub(crate) static ref HANDLEBARS: RwLock<Box<Handlebars<'static>>> = {
         let mut handlebars = Handlebars::new();
         handlebars.register_escape_fn(handlebars::no_escape);
+        handlebars.register_helper("uuid", Box::new(uuid_generator));
+        handlebars.register_helper("id", Box::new(id_generator));
         RwLock::new(Box::new(handlebars))
     };
 }
@@ -67,4 +98,46 @@ impl HttpStaticPluginBuilder {
             config: plugin_config,
         })
     }
+}
+
+#[test]
+fn test_unique_uuid() {
+    let mut handlebars = Handlebars::new();
+    handlebars.register_escape_fn(handlebars::no_escape);
+    handlebars.register_helper("uuid", Box::new(uuid_generator));
+
+    handlebars
+        .register_template_string("uuid", "{{ uuid }}\n{{ uuid }}")
+        .unwrap();
+    let rendered = handlebars.render("uuid", &serde_json::Value::Null).unwrap();
+
+    let lines: Vec<&str> = rendered.split('\n').collect();
+    assert_eq!(2, lines.len());
+    assert_ne!(lines[0], lines[1]);
+}
+
+#[test]
+fn test_unique_id() {
+    let mut handlebars = Handlebars::new();
+    handlebars.register_escape_fn(handlebars::no_escape);
+    handlebars.register_helper("id", Box::new(id_generator));
+
+    let start = ID_COUNTER.load(Ordering::SeqCst);
+
+    handlebars
+        .register_template_string("id", "{{ id }}\n{{ id }}")
+        .unwrap();
+    let rendered = handlebars.render("id", &serde_json::Value::Null).unwrap();
+
+    let lines: Vec<&str> = rendered.split('\n').collect();
+    assert_eq!(2, lines.len());
+    assert_eq!(start, lines[0].parse::<u64>().unwrap());
+    assert_eq!(start + 1, lines[1].parse::<u64>().unwrap());
+
+    let rendered = handlebars.render("id", &serde_json::Value::Null).unwrap();
+
+    let lines: Vec<&str> = rendered.split('\n').collect();
+    assert_eq!(2, lines.len());
+    assert_eq!(start + 2, lines[0].parse::<u64>().unwrap());
+    assert_eq!(start + 3, lines[1].parse::<u64>().unwrap());
 }


### PR DESCRIPTION
Before `uuid` was set once, which meant that if it was used more than once in a file, it would be the same across files.